### PR TITLE
DEVOPS-210 - Enable Dependabot on the Generated Docker files.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,30 @@ updates:
       interval: "daily"
     reviewers:
       - "hostpapa/eng-enablement"
+  # Maintain dependencies for 8.0
+  - package-ecosystem: "docker"
+    directory: "/8.0/alpine3.16/fpm-nginx"
+    registries:
+      - ghcr
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "hostpapa/eng-enablement"
+  # Maintain dependencies for 8.1
+  - package-ecosystem: "docker"
+    directory: "/8.1/alpine3.18/fpm-nginx"
+    registries:
+      - ghcr
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "hostpapa/eng-enablement"
+  # Maintain dependencies for 8.2
+  - package-ecosystem: "docker"
+    directory: "/8.2/alpine3.18/fpm-nginx"
+    registries:
+      - ghcr
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "hostpapa/eng-enablement"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
   # Maintain dependencies for 8.0
   - package-ecosystem: "docker"
     directory: "/8.0/alpine3.16/fpm-nginx"
-    registries:
-      - ghcr
     schedule:
       interval: "daily"
     reviewers:
@@ -19,8 +17,6 @@ updates:
   # Maintain dependencies for 8.1
   - package-ecosystem: "docker"
     directory: "/8.1/alpine3.18/fpm-nginx"
-    registries:
-      - ghcr
     schedule:
       interval: "daily"
     reviewers:
@@ -28,8 +24,6 @@ updates:
   # Maintain dependencies for 8.2
   - package-ecosystem: "docker"
     directory: "/8.2/alpine3.18/fpm-nginx"
-    registries:
-      - ghcr
     schedule:
       interval: "daily"
     reviewers:


### PR DESCRIPTION
**Description:**
This PR enables dependabot to watch over the Generated Docker files for PHP 8.0, 8.1, and 8.2