### PR TITLE
DEVOPS-210 - Added Ignore for Major version updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
     directory: "/8.0/alpine3.16/fpm-nginx"
     schedule:
       interval: "daily"
+    ignore:
+      # For all images, ignore all major updates
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     reviewers:
       - "hostpapa/eng-enablement"
   # Maintain dependencies for 8.1
@@ -19,6 +23,10 @@ updates:
     directory: "/8.1/alpine3.18/fpm-nginx"
     schedule:
       interval: "daily"
+    ignore:
+      # For all images, ignore all major updates
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     reviewers:
       - "hostpapa/eng-enablement"
   # Maintain dependencies for 8.2
@@ -26,5 +34,9 @@ updates:
     directory: "/8.2/alpine3.18/fpm-nginx"
     schedule:
       interval: "daily"
+    ignore:
+      # For all images, ignore all major updates
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     reviewers:
       - "hostpapa/eng-enablement"


### PR DESCRIPTION
**Description:**
This PR will help dependabot update the minor versions but ignore the updates for the major versions so our images can stay up to date and not get upgraded by Dependabot.