### PR TITLE
DEVOPS-204 - Added the missing command which causes issues with the images

### DIFF
--- a/8.0/alpine3.16/fpm-nginx/Dockerfile
+++ b/8.0/alpine3.16/fpm-nginx/Dockerfile
@@ -61,6 +61,8 @@ RUN set -eux; \
     && adduser -S -D -H -u 101 -h /var/cache/nginx -s /sbin/nologin -G nginx -g nginx nginx \
     && apk add --no-cache \
         nginx \
+# Move http.d to conf.d to match other Nginx setups and scripts
+    && mv /etc/nginx/http.d /etc/nginx/conf.d \
 # Replace references to http.d with conf.d in main Nginx config installed by default
 # This allows this image to function on its own even though most will override nginx.conf entirely
     && sed -i 's/http.d/conf.d/g' /etc/nginx/nginx.conf \

--- a/8.1/alpine3.18/fpm-nginx/Dockerfile
+++ b/8.1/alpine3.18/fpm-nginx/Dockerfile
@@ -61,6 +61,8 @@ RUN set -eux; \
     && adduser -S -D -H -u 101 -h /var/cache/nginx -s /sbin/nologin -G nginx -g nginx nginx \
     && apk add --no-cache \
         nginx \
+# Move http.d to conf.d to match other Nginx setups and scripts
+    && mv /etc/nginx/http.d /etc/nginx/conf.d \
 # Replace references to http.d with conf.d in main Nginx config installed by default
 # This allows this image to function on its own even though most will override nginx.conf entirely
     && sed -i 's/http.d/conf.d/g' /etc/nginx/nginx.conf \

--- a/8.2/alpine3.18/fpm-nginx/Dockerfile
+++ b/8.2/alpine3.18/fpm-nginx/Dockerfile
@@ -61,6 +61,8 @@ RUN set -eux; \
     && adduser -S -D -H -u 101 -h /var/cache/nginx -s /sbin/nologin -G nginx -g nginx nginx \
     && apk add --no-cache \
         nginx \
+# Move http.d to conf.d to match other Nginx setups and scripts
+    && mv /etc/nginx/http.d /etc/nginx/conf.d \
 # Replace references to http.d with conf.d in main Nginx config installed by default
 # This allows this image to function on its own even though most will override nginx.conf entirely
     && sed -i 's/http.d/conf.d/g' /etc/nginx/nginx.conf \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -70,6 +70,8 @@ RUN set -eux; \
     && adduser -S -D -H -u 101 -h /var/cache/nginx -s /sbin/nologin -G nginx -g nginx nginx \
     && apk add --no-cache \
         nginx \
+# Move http.d to conf.d to match other Nginx setups and scripts
+    && mv /etc/nginx/http.d /etc/nginx/conf.d \
 # Replace references to http.d with conf.d in main Nginx config installed by default
 # This allows this image to function on its own even though most will override nginx.conf entirely
     && sed -i 's/http.d/conf.d/g' /etc/nginx/nginx.conf \


### PR DESCRIPTION
**Description:**
The recently build images were throwing a 502 when testing with `Satis Server`. After some debugging, it turns out that it was missing this one command which fixes the 502 error. With this command, Satis was working as expected.