### PR TITLE
PD-2425 - Install Mail Client for Alpine Image to be able to send emails

### DIFF
--- a/8.0/alpine3.16/fpm-nginx/Dockerfile
+++ b/8.0/alpine3.16/fpm-nginx/Dockerfile
@@ -52,6 +52,8 @@ RUN set -eux; \
             | sort -u \
             | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
     )"; \
+    # Setup Mail client
+    apk add msmtp; \
     apk add --no-network --virtual .wordpress-phpexts-rundeps $runDeps; \
     apk del --no-network .build-deps \
     ; \

--- a/8.0/alpine3.16/fpm-nginx/Dockerfile
+++ b/8.0/alpine3.16/fpm-nginx/Dockerfile
@@ -15,6 +15,7 @@ RUN set -eux; \
         curl \
         ca-certificates \
         supervisor \
+        msmtp \
     ; \
 ### Setup needed PHP dependencies ###
 # Install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
@@ -52,8 +53,6 @@ RUN set -eux; \
             | sort -u \
             | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
     )"; \
-    # Setup Mail client
-    apk add msmtp; \
     apk add --no-network --virtual .wordpress-phpexts-rundeps $runDeps; \
     apk del --no-network .build-deps \
     ; \

--- a/8.1/alpine3.18/fpm-nginx/Dockerfile
+++ b/8.1/alpine3.18/fpm-nginx/Dockerfile
@@ -52,6 +52,8 @@ RUN set -eux; \
             | sort -u \
             | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
     )"; \
+    # Setup Mail client
+    apk add msmtp; \
     apk add --no-network --virtual .wordpress-phpexts-rundeps $runDeps; \
     apk del --no-network .build-deps \
     ; \

--- a/8.1/alpine3.18/fpm-nginx/Dockerfile
+++ b/8.1/alpine3.18/fpm-nginx/Dockerfile
@@ -15,6 +15,7 @@ RUN set -eux; \
         curl \
         ca-certificates \
         supervisor \
+        msmtp \
     ; \
 ### Setup needed PHP dependencies ###
 # Install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
@@ -52,8 +53,6 @@ RUN set -eux; \
             | sort -u \
             | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
     )"; \
-    # Setup Mail client
-    apk add msmtp; \
     apk add --no-network --virtual .wordpress-phpexts-rundeps $runDeps; \
     apk del --no-network .build-deps \
     ; \

--- a/8.2/alpine3.18/fpm-nginx/Dockerfile
+++ b/8.2/alpine3.18/fpm-nginx/Dockerfile
@@ -52,6 +52,8 @@ RUN set -eux; \
             | sort -u \
             | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
     )"; \
+    # Setup Mail client
+    apk add msmtp; \
     apk add --no-network --virtual .wordpress-phpexts-rundeps $runDeps; \
     apk del --no-network .build-deps \
     ; \

--- a/8.2/alpine3.18/fpm-nginx/Dockerfile
+++ b/8.2/alpine3.18/fpm-nginx/Dockerfile
@@ -15,6 +15,7 @@ RUN set -eux; \
         curl \
         ca-certificates \
         supervisor \
+        msmtp \
     ; \
 ### Setup needed PHP dependencies ###
 # Install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
@@ -52,8 +53,6 @@ RUN set -eux; \
             | sort -u \
             | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
     )"; \
-    # Setup Mail client
-    apk add msmtp; \
     apk add --no-network --virtual .wordpress-phpexts-rundeps $runDeps; \
     apk del --no-network .build-deps \
     ; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -24,6 +24,7 @@ RUN set -eux; \
         curl \
         ca-certificates \
         supervisor \
+        msmtp \
     ; \
 ### Setup needed PHP dependencies ###
 # Install the PHP extensions we need (https://make.wordpress.org/hosting/handbook/handbook/server-environment/#php-extensions)
@@ -61,8 +62,6 @@ RUN set -eux; \
             | sort -u \
             | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
     )"; \
-    # Setup Mail client
-    apk add msmtp; \
     apk add --no-network --virtual .wordpress-phpexts-rundeps $runDeps; \
     apk del --no-network .build-deps \
     ; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -61,6 +61,8 @@ RUN set -eux; \
             | sort -u \
             | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
     )"; \
+    # Setup Mail client
+    apk add msmtp; \
     apk add --no-network --virtual .wordpress-phpexts-rundeps $runDeps; \
     apk del --no-network .build-deps \
     ; \


### PR DESCRIPTION
**Description:**
This PR updates the base image to allow WordPress applications to send emails. This is specifically needed in our case where we run the cron jobs and it calls upon a shell script that will send an email for the outdated WordPress plugins.
