### PR TITLE
PD-2425 - Switch from ARMv8 to ARM64 Arch.

### DIFF
--- a/.github/workflows/build-v80.yml
+++ b/.github/workflows/build-v80.yml
@@ -88,7 +88,7 @@ jobs:
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09
         with:
           context: ./8.0/alpine3.16/fpm-nginx/
-          platforms: linux/amd64,linux/arm/v8
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-v81.yml
+++ b/.github/workflows/build-v81.yml
@@ -88,7 +88,7 @@ jobs:
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09
         with:
           context: ./8.1/alpine3.18/fpm-nginx/
-          platforms: linux/amd64,linux/arm/v8
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-v82.yml
+++ b/.github/workflows/build-v82.yml
@@ -88,7 +88,7 @@ jobs:
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09
         with:
           context: ./8.2/alpine3.18/fpm-nginx/
-          platforms: linux/amd64,linux/arm/v8
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
**Description:**
As per https://github.com/DataDog/dd-trace-php/issues/2279, this PR switches the ARM arch from `v8` to `64` in order to build for 64 bit systems on Apple Silicon based machines.